### PR TITLE
Restrict clearpuggers to preset roles

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -241,14 +241,13 @@ async def unpug(ctx):
 async def clearpuggers(ctx):
     if ctx.guild not in pug_guilds or not ctx.channel.name == PUG_CHANNEL_NAME:
         return
-    pug_admin_role= CFG["pug_admin_role_name"].value
+    pug_admin_role = CFG["pug_admin_role_name"].value
     role_names = [role.name for role in ctx.message.author.roles]
     if (pug_admin_role in role_names) or ("Admins" in role_names):
         pug_guilds[ctx.guild].reset()
         await ctx.send(f"{ctx.message.author.name} has reset the PUG queue")
     else:
         return
-
 
 
 @bot.command(brief="Get new random teams suggestion for the latest PUG")

--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,7 @@ import requests
 
 
 SCRIPT_NAME = "NT Pug Bot"
-SCRIPT_VERSION = "0.6.1"
+SCRIPT_VERSION = "0.7.0"
 SCRIPT_URL = "https://github.com/Rainyan/discord-bot-ntpug"
 
 CFG_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),

--- a/bot.py
+++ b/bot.py
@@ -31,6 +31,7 @@ with open(CFG_PATH, "r") as f:
         "pugger_role_name": Str(),
         "pugger_role_ping_threshold": Float(),
         "pugger_role_min_ping_interval_hours": Float(),
+        "pug_admin_role_name": Str(),
     })
     CFG = load(f.read(), YAML_CFG_SCHEMA)
 assert CFG is not None
@@ -240,8 +241,14 @@ async def unpug(ctx):
 async def clearpuggers(ctx):
     if ctx.guild not in pug_guilds or not ctx.channel.name == PUG_CHANNEL_NAME:
         return
-    pug_guilds[ctx.guild].reset()
-    await ctx.send(f"{ctx.message.author.name} has reset the PUG queue")
+    pug_admin_role= CFG["pug_admin_role_name"].value
+    role_names = [role.name for role in ctx.message.author.roles]
+    if (pug_admin_role in role_names) or ("Admins" in role_names):
+        pug_guilds[ctx.guild].reset()
+        await ctx.send(f"{ctx.message.author.name} has reset the PUG queue")
+    else:
+        return
+
 
 
 @bot.command(brief="Get new random teams suggestion for the latest PUG")

--- a/config.yml
+++ b/config.yml
@@ -32,3 +32,6 @@ pugger_role_ping_threshold: 0.5
 
 # How long to wait, in hours, between role pings at a minimum.
 pugger_role_min_ping_interval_hours: 4.0
+
+# Name of the pug maintainer role
+pug_admin_role_name: Moderators


### PR DESCRIPTION
The command is currently exploitable. Dropping the fix.