### PR TITLE
Add failsafe for HTTP errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -229,9 +229,9 @@ class PugStatus():
         # We can also hit a HTTP 429 here, which might be a pycord bug(?)
         # as I don't think we're being unreasonable with the history range.
         except discord.errors.HTTPException as err:
-            self.nsf_players = backup_nsf
-            self.jin_players = backup_jin
-            self.prev_puggers = backup_prev
+            self.nsf_players = backup_nsf.copy()
+            self.jin_players = backup_jin.copy()
+            self.prev_puggers = backup_prev.copy()
             raise
 
     async def player_leave(self, player):

--- a/bot.py
+++ b/bot.py
@@ -144,8 +144,8 @@ class PugStatus():
         """
         async with self.lock:
             self.prev_puggers = self.jin_players + self.nsf_players
-            self.jin_players = []
-            self.nsf_players = []
+            self.jin_players.clear()
+            self.nsf_players.clear()
 
     async def player_join(self, player, team=None):
         """If there is enough room in this PUG queue, assigns this player

--- a/bot.py
+++ b/bot.py
@@ -232,7 +232,7 @@ class PugStatus():
             self.nsf_players = backup_nsf.copy()
             self.jin_players = backup_jin.copy()
             self.prev_puggers = backup_prev.copy()
-            raise
+            raise err
 
     async def player_leave(self, player):
         """Removes a player from the pugger queue if they were in it.

--- a/bot.py
+++ b/bot.py
@@ -668,14 +668,15 @@ class PugQueueCog(commands.Cog):
         """
         async with self.lock:
             for guild in bot.guilds:
+                if guild not in pug_guilds:
+                    continue
+                if pug_guilds[guild].is_full():
+                    continue
                 for channel in guild.channels:
                     if channel.name != PUG_CHANNEL_NAME:
                         continue
-                    if guild not in pug_guilds:
-                        continue
-                    if pug_guilds[guild].is_full():
-                        continue
                     await pug_guilds[guild].reload_puggers()
+                    break
 
 
 bot.add_cog(ErrorHandlerCog(bot))

--- a/bot.py
+++ b/bot.py
@@ -62,7 +62,7 @@ from strictyaml.ruamel.comments import CommentedSeq
 assert discord.version_info.major == 1 and discord.version_info.minor == 7
 
 SCRIPT_NAME = "NT Pug Bot"
-SCRIPT_VERSION = "0.13.1"
+SCRIPT_VERSION = "0.14.0"
 
 CFG_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                         "config.yml")


### PR DESCRIPTION
Recover previously active pugger lists in case we get a HTTP error from Discord API while running updates. This fixes a problem where the pugger queue could unintentionally get wiped when an API operation didn't succeed.